### PR TITLE
Potential fix for code scanning alert no. 25: DOM text reinterpreted as HTML

### DIFF
--- a/app/views/page/seqcode.html.erb
+++ b/app/views/page/seqcode.html.erb
@@ -20,7 +20,7 @@
     $(this).attr('href', '#' + $(this).parent().attr('id'));
   });
   $('#seqcode-down .link-to-id [name]').each(function(idx){
-    $(this).siblings('.linker').attr('href', '#' + $(this).attr('name'));
+    $(this).siblings('.linker').attr('href', '#' + encodeURIComponent($(this).attr('name')));
   });
   // Smooth scrolling
   $(document).on('click', 'a[href^="#"]', function (event) {


### PR DESCRIPTION
Potential fix for [https://github.com/seq-code/registry/security/code-scanning/25](https://github.com/seq-code/registry/security/code-scanning/25)

To fix the error, we must ensure that any value read from `$(this).attr('name')` is properly escaped before being inserted into the DOM as part of an attribute value. For this case (fragment identifier), we should sanitize the name so that only valid fragment identifiers are used, ideally restricting the set to a safe subset (e.g., `[A-Za-z0-9\-_:.]+`). The best way is to filter and encode the fragment identifier using JavaScript’s `encodeURIComponent`. This prevents `"` and other unsafe characters from being misinterpreted or injected into the HTML context. The fix should be applied only to line 23 in `app/views/page/seqcode.html.erb`, wrapping the value of `$(this).attr('name')` in `encodeURIComponent()`. No external dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
