### PR TITLE
Improve nomenclatural_type handling and add API glossary

### DIFF
--- a/app/views/names/_nomenclatural_type.json.jbuilder
+++ b/app/views/names/_nomenclatural_type.json.jbuilder
@@ -1,4 +1,4 @@
-json.class(object ? object.class.to_s : 'unknown')
+json.class(object&.respond_to?(:type_of_type) ? object.type_of_type : 'unknown')
 json.id(object.try(:id))
 json.url(object ? polymorphic_url(object, format: :json) : nil)
 json.uri object.try(:uri)

--- a/docs/api_glossary.md
+++ b/docs/api_glossary.md
@@ -1,0 +1,66 @@
+---
+# API Glossary
+
+This glossary defines the enums, objects, and special fields used in the SeqCode Registry API.
+
+---
+
+## Enums
+
+### `status_name`
+The status of a name in the registry. Possible values:
+
+- **`public`**: Publicly available.
+- **`automated`**: Automatically generated.
+- **`SeqCode`**: Valid under the SeqCode.
+- **`ICNP`**: Valid under the International Code of Nomenclature of Prokaryotes.
+- **`ICNafp`**: Valid under the International Code of Nomenclature for algae, fungi, and plants.
+- **`valid`**: Valid under any code.
+
+---
+
+### `kind` (for genomes)
+The kind of genome. Possible values:
+
+- **`isolate`**: Genome from a single isolate.
+- **`enrichment`**: Enriched community genome.
+- **`mag`**: Metagenome-assembled genome.
+- **`sag`**: Single-cell amplified genome.
+- **`null`**: Unknown or not applicable.
+
+---
+
+### `rank`
+The taxonomic rank of a name. Possible values:
+
+- **`domain`**
+- **`kingdom`**
+- **`phylum`**
+- **`class`**
+- **`order`**
+- **`family`**
+- **`genus`**
+- **`species`**
+- **`subspecies`**
+
+---
+
+## Special Fields
+
+### `nomenclatural_type` (Object)
+The nomenclatural type associated with a name. This is a **hash (object)** with the following structure:
+
+| Key       | Type   | Description                                                                                     | Example Value                     |
+|-----------|--------|-------------------------------------------------------------------------------------------------|-----------------------------------|
+| `class`   | string | The **type** of the nomenclatural type. Possible values: `Name`, `Genome`, `Strain`, `Other`, `unknown`. | `"Name"`, `"Genome"`, `"Other"`, `"unknown"` |
+| `id`      | int    | The unique identifier of the nomenclatural type (if applicable).                                | `26160`                          |
+| `url`     | string | The URL to the nomenclatural type resource (if applicable).                                    | `"https://api.seqco.de/v1/names/26160.json"` |
+| `uri`     | string | The URI of the nomenclatural type (if applicable).                                             | `"https://seqco.de/i:26160"`     |
+| `display` | string | A human-readable display name for the nomenclatural type (if applicable).                     | `"Desulfogranum mediterraneum"` |
+
+##### Possible Values for `class`:
+- **`"Name"`**: The nomenclatural type is another **Name** (e.g., a type species for a genus).
+- **`"Genome"`**: The nomenclatural type is a **Genome** (e.g., a type genome for a species).
+- **`"Strain"`**: The nomenclatural type is a **Strain** (e.g., a type strain for a species).
+- **`"Other"`**: The nomenclatural type is a **GenericTypeMaterial** (e.g., any other type of material).
+- **`"unknown"`**: The nomenclatural type is **not defined** or **unknown**.


### PR DESCRIPTION
This PR includes two improvements:

1. **Code Improvement**: Updated `app/views/names/_nomenclatural_type.json.jbuilder` to safely handle cases where the object is `nil` or does not respond to `type_of_type`. The new logic uses Ruby's safe navigation operator (`&.`) and `respond_to?` to ensure robustness, returning `'unknown'` as a fallback.

2. **Documentation Improvement**: Added a new `docs/api_glossary.md` file that documents all enums (`status_name`, `kind`, `rank`) and special fields like `nomenclatural_type` used in the SeqCode Registry API. The `nomenclatural_type` field is now clearly documented as a hash object with a `class` key that can have values: `Name`, `Genome`, `Strain`, `Other`, or `unknown`. The `Other` value is included as it is returned by `GenericTypeMaterial#type_of_type`.

These changes improve both the reliability of the API and the clarity of its documentation.