### PR TITLE
Fix namespace conflict for Name service objects

### DIFF
--- a/app/services/name/fuzzy_search.rb
+++ b/app/services/name/fuzzy_search.rb
@@ -1,71 +1,73 @@
 # frozen_string_literal: true
 
-module Name
-  # Service object to handle fuzzy search for names.
-  # This encapsulates the logic for finding similar names using
-  # PostgreSQL's similarity functions.
-  class FuzzySearch
-    # Performs a fuzzy search for names similar to the given query.
-    # @param query [String] The search query.
-    # @param method [Symbol] The search method (:similarity or :levenshtein).
-    # @param threshold [Float, Integer] The threshold for matching.
-    # @param limit [Integer] The maximum number of results to return.
-    # @param selection [Symbol, ActiveRecord::Relation] The selection of names to search.
-    #   Can be :all_valid, :all_public, :valid_genera, :public_genera, or a custom query.
-    # @return [ActiveRecord::Relation] The matching names.
-    def self.call(
-      query,
-      method: :similarity,
-      threshold: nil,
-      limit: 10,
-      selection: :all_valid
-    )
-      return unless ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+module Services
+  module Name
+    # Service object to handle fuzzy search for names.
+    # This encapsulates the logic for finding similar names using
+    # PostgreSQL's similarity functions.
+    class FuzzySearch
+      # Performs a fuzzy search for names similar to the given query.
+      # @param query [String] The search query.
+      # @param method [Symbol] The search method (:similarity or :levenshtein).
+      # @param threshold [Float, Integer] The threshold for matching.
+      # @param limit [Integer] The maximum number of results to return.
+      # @param selection [Symbol, ActiveRecord::Relation] The selection of names to search.
+      #   Can be :all_valid, :all_public, :valid_genera, :public_genera, or a custom query.
+      # @return [ActiveRecord::Relation] The matching names.
+      def self.call(
+        query,
+        method: :similarity,
+        threshold: nil,
+        limit: 10,
+        selection: :all_valid
+      )
+        return unless ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
 
-      selection = resolve_selection(selection)
-      clean_query = ActiveRecord::Base.connection.quote(query)
+        selection = resolve_selection(selection)
+        clean_query = ActiveRecord::Base.connection.quote(query)
 
-      case method.to_sym
-      when :similarity
-        perform_similarity_search(selection, clean_query, threshold || 0.7, limit)
-      when :levenshtein
-        perform_levenshtein_search(selection, clean_query, threshold || 2, limit)
-      else
-        raise ArgumentError, "Unsupported fuzzy match method: #{method}"
+        case method.to_sym
+        when :similarity
+          perform_similarity_search(selection, clean_query, threshold || 0.7, limit)
+        when :levenshtein
+          perform_levenshtein_search(selection, clean_query, threshold || 2, limit)
+        else
+          raise ArgumentError, "Unsupported fuzzy match method: #{method}"
+        end
       end
-    end
 
-    private_class_method def self.resolve_selection(selection)
-      case selection
-      when :all_valid
-        Name.all_valid
-      when :all_public
-        Name.all_public
-      when :valid_genera
-        Name.all_valid.where(rank: :genus)
-      when :public_genera
-        Name.all_public.where(rank: :genus)
-      when ActiveRecord::Relation
+      private_class_method def self.resolve_selection(selection)
+        case selection
+        when :all_valid
+          ::Name.all_valid
+        when :all_public
+          ::Name.all_public
+        when :valid_genera
+          ::Name.all_valid.where(rank: :genus)
+        when :public_genera
+          ::Name.all_public.where(rank: :genus)
+        when ActiveRecord::Relation
+          selection
+        else
+          raise ArgumentError, "Unsupported selection: #{selection}"
+        end
+      end
+
+      private_class_method def self.perform_similarity_search(selection, query, threshold, limit)
         selection
-      else
-        raise ArgumentError, "Unsupported selection: #{selection}"
+          .select("id, name, similarity(name, #{query}) AS score")
+          .where('similarity(name, ?) > ?', query, threshold)
+          .order('score DESC')
+          .limit(limit)
       end
-    end
 
-    private_class_method def self.perform_similarity_search(selection, query, threshold, limit)
-      selection
-        .select("id, name, similarity(name, #{query}) AS score")
-        .where('similarity(name, ?) > ?', query, threshold)
-        .order('score DESC')
-        .limit(limit)
-    end
-
-    private_class_method def self.perform_levenshtein_search(selection, query, threshold, limit)
-      selection
-        .select("id, name, levenshtein(name, #{query}) AS score")
-        .where('levenshtein(name, ?) <= ?', query, threshold)
-        .order('score ASC')
-        .limit(limit)
+      private_class_method def self.perform_levenshtein_search(selection, query, threshold, limit)
+        selection
+          .select("id, name, levenshtein(name, #{query}) AS score")
+          .where('levenshtein(name, ?) <= ?', query, threshold)
+          .order('score ASC')
+          .limit(limit)
+      end
     end
   end
 end

--- a/app/services/name/type_resolver.rb
+++ b/app/services/name/type_resolver.rb
@@ -1,27 +1,29 @@
 # frozen_string_literal: true
 
-module Name
-  # Service object to resolve the nomenclatural type for a name.
-  # This encapsulates the logic for determining the type_of_type value
-  # and handling edge cases.
-  class TypeResolver
-    # Resolves the nomenclatural type class for a given object.
-    # @param object [Object, nil] The object to resolve (e.g., a Name, Genome, or Strain).
-    # @return [String] The resolved type_of_type value, or 'unknown' if unresolved.
-    def self.resolve(object)
-      return 'unknown' if object.nil?
-      return object.type_of_type if object.respond_to?(:type_of_type)
-      'unknown'
-    end
+module Services
+  module Name
+    # Service object to resolve the nomenclatural type for a name.
+    # This encapsulates the logic for determining the type_of_type value
+    # and handling edge cases.
+    class TypeResolver
+      # Resolves the nomenclatural type class for a given object.
+      # @param object [Object, nil] The object to resolve (e.g., a Name, Genome, or Strain).
+      # @return [String] The resolved type_of_type value, or 'unknown' if unresolved.
+      def self.resolve(object)
+        return 'unknown' if object.nil?
+        return object.type_of_type if object.respond_to?(:type_of_type)
+        'unknown'
+      end
 
-    # Resolves the nomenclatural type class for a given object, with additional context.
-    # @param object [Object, nil] The object to resolve.
-    # @param context [Hash] Additional context (e.g., { fallback: 'Name' }).
-    # @return [String] The resolved type_of_type value.
-    def self.resolve_with_context(object, context = {})
-      resolved = resolve(object)
-      return resolved unless resolved == 'unknown' && context[:fallback].present?
-      context[:fallback]
+      # Resolves the nomenclatural type class for a given object, with additional context.
+      # @param object [Object, nil] The object to resolve.
+      # @param context [Hash] Additional context (e.g., { fallback: 'Name' }).
+      # @return [String] The resolved type_of_type value.
+      def self.resolve_with_context(object, context = {})
+        resolved = resolve(object)
+        return resolved unless resolved == 'unknown' && context[:fallback].present?
+        context[:fallback]
+      end
     end
   end
 end


### PR DESCRIPTION
This PR fixes a **namespace conflict** introduced in PR #255. The issue occurred because the service objects (`Name::FuzzySearch` and `Name::TypeResolver`) were defined inside a `Name` module, which conflicts with the existing `Name` model class in Rails.

---

## 🐛 Problem
In Ruby, you cannot have both a **class** and a **module** with the same name in the same namespace. The `Name` model class (in `app/models/name.rb`) and the `Name` module (in `app/services/name/*.rb`) caused the following error in production:
```
Name is not a module (TypeError)
```

---

## ✅ Solution
Renamed the module namespace from `Name` to `Services::Name` to avoid the conflict. This ensures:
- The `Name` model class remains unchanged.
- The service objects are properly namespaced under `Services::Name`.
- All references to the `Name` model inside the service objects now use `::Name` to explicitly reference the class.

---

## 📝 Changes Made
1. **`app/services/name/fuzzy_search.rb`**:
   - Changed `module Name` to `module Services::Name`.
   - Updated all references to `Name` (the model) to `::Name`.

2. **`app/services/name/type_resolver.rb`**:
   - Changed `module Name` to `module Services::Name`.

---

## 🔄 Backward Compatibility
- The service objects are **not currently used** in the codebase (they were added in PR #255 but not referenced elsewhere).
- If you plan to use these services in the future, update the references to use the new namespace:
  ```ruby
  Services::Name::FuzzySearch.call(query)
  Services::Name::TypeResolver.resolve(object)
  ```

---

## 🚀 Next Steps
- Merge this PR to resolve the production error.
- Update any future references to these service objects to use the `Services::Name` namespace.

---

## 📚 Related PRs
- Fixes the issue introduced in [PR #255](https://github.com/seq-code/registry/pull/255).