### PR TITLE
Fix dependency versions to work with Rails 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,11 +63,13 @@ gem 'wkhtmltopdf-binary', '<= 0.12.6.6' # TODO Temporary fix for large gem
 gem 'yui-compressor', '>= 0.12'
 
 group :development, :test do
+  # Rails 6.1's test runner is not compatible with Minitest 6's run signature.
+  gem 'minitest', '< 6'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger
   # console
   gem 'byebug', platforms: %i[mri windows]
   # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '~> 2.13'
+  gem 'capybara', '>= 3.26'
   gem 'selenium-webdriver'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,13 +78,15 @@ GEM
     builder (3.3.0)
     byebug (13.0.0)
       reline (>= 0.6.0)
-    capybara (2.18.0)
+    capybara (3.40.0)
       addressable
+      matrix
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     chronic (0.10.2)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -113,7 +115,6 @@ GEM
       responders
       warden (~> 1.2.3)
     dkim (1.1.0)
-    drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
     execjs (2.10.1)
@@ -185,6 +186,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.1.0)
+    matrix (0.4.3)
     method_source (1.1.0)
     miga-base (1.4.2.4)
       daemons (~> 1.3)
@@ -198,9 +200,7 @@ GEM
       logger
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (6.0.6)
-      drb (~> 2.0)
-      prism (~> 1.5)
+    minitest (5.27.0)
     multi_json (1.21.1)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
@@ -465,7 +465,7 @@ DEPENDENCIES
   benchmark
   bootstrap (~> 4.6.2)
   byebug
-  capybara (~> 2.13)
+  capybara (>= 3.26)
   coffee-rails (~> 5.0)
   csv
   d3-rails
@@ -481,6 +481,7 @@ DEPENDENCIES
   jquery-rails
   listen (>= 3.0.5, < 3.2)
   miga-base (~> 1.3)
+  minitest (< 6)
   mutex_m
   pdf-reader
   pg


### PR DESCRIPTION
I had to pin these versions to get Rails running.

- Rails 6 does not work with Minitest >= 6
- Rails 6 requires Capybara 3.26