### PR TITLE
Development dependency: ruby-lsp for editor extensions (VSCode, Zed)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,8 @@ group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere
   # in the code.
   gem 'web-console', '>= 3.3.0'
+  # Language server for VSCode, Zed etc.
+  gem 'ruby-lsp'
 end
 
 group :rubocop do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,6 +295,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rbs (4.0.2)
+      logger
+      prism (>= 1.6.0)
+      tsort
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -340,6 +344,10 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.44.0, < 2.0)
+    ruby-lsp (0.26.9)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 1.2, < 2.0)
+      rbs (>= 3, < 5)
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby-vips (2.3.0)
@@ -497,6 +505,7 @@ DEPENDENCIES
   rubocop-packaging
   rubocop-performance
   rubocop-rails
+  ruby-lsp
   sass-rails (~> 5.0)
   selenium-webdriver
   serrano (~> 1.0)


### PR DESCRIPTION
ruby-lsp is a language server for Ruby that lets code editors provide features such as "navigate to function", symbol lists etc. Very useful and development-only dependency. It is possible to use it without adding it to the Gemfile of the project, but it is a bit of a hack, so would be nice if we could add it.