### PR TITLE
Use Rails 5.2 defaults

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
   include PageHelper
 
-  protect_from_forgery(with: :exception)
   before_action(:check_api!)
   before_action(:store_user_location!, if: :storable_location?)
 


### PR DESCRIPTION
The one necessary change was to remove `protect_from_forgery(with: :exception)` since this is now implicitly part of the controller callbacks. Verified with:

```
% bundle exec rails runner 'ApplicationController._process_action_callbacks.select { |cb| cb.kind == :before }.each_with_index { |cb, i| puts "#{i+1}: #{cb.filter.inspect}" }'
1: :verify_authenticity_token
2: :set_turbolinks_location_header_from_session
3: :check_api!
4: :store_user_location!
```

which still includes `verify_authenticity_token`.

Part of #277.