### PR TITLE
Deliver cron reminder emails synchronously

### DIFF
--- a/app/models/reminder_mail.rb
+++ b/app/models/reminder_mail.rb
@@ -18,7 +18,7 @@ class ReminderMail < ApplicationRecord
         unless registers.empty?
           AdminMailer.with(user: user, registers: registers)
                      .register_reminder_email
-                     .deliver_later
+                     .deliver_now
         end
       end
     end


### PR DESCRIPTION
Rails runner exits immediately, dropping any pending jobs, which means that mails are not sent. Delivering them synchronously should fix this.

See https://github.com/seq-code/registry/issues/262#issuecomment-4738749191 for background.