### PR TITLE
Send mails in `after_create_commit` hook

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -11,7 +11,9 @@ class Contact < ApplicationRecord
 
   has_rich_text(:message)
 
-  after_create(:send_message)
+  # Enqueue email only after commit to avoid timing issues where the job runs
+  # before the contact creation is visible outside the transaction.
+  after_create_commit(:send_message)
 
   def default_message
     <<~MSG

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,7 +3,9 @@ class Notification < ApplicationRecord
   belongs_to :notifiable, polymorphic: true
   belongs_to :linkeable, polymorphic: true, optional: true
 
-  after_create(:send_email_notification)
+  # Enqueue email only after commit to avoid timing issues where the job runs
+  # before the notification creation is visible outside the transaction.
+  after_create_commit(:send_email_notification)
   after_save(:broadcast_notification_count)
   after_create(:broadcast_web_notification)
 


### PR DESCRIPTION
#262 

The [AsyncAdapter](https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/AsyncAdapter.html) will run jobs immediately. When a mail is sent via `perform_later` in an `after_create` hook, the job could run before the record exists in the database, since `after_create` hooks are executed *before* the transaction is completed:

1.  `Contact.create` opens a new transaction.
2. `after_create` is run with the transaction still open.
3. If the job runs before the transaction is committed, the `Contact` record does not exist yet.

By changing to an `after_create_commit` hook, we ensure that the `Contact` actually exists. Same goes for `Notification`.

I can reproduce this consistently in the production console:

```ruby
original = Contact.find(30)

Contact.transaction do
  c = original.dup
  c.subject = "ASYNC BAD #{Time.now}"
  c.message = original.message.body.to_html
  c.save!

  puts "created #{c.id}; holding transaction open"
  sleep 1
end
```

This never sends an email. If I manually switch out the hooks and run the above block again, it reliably sends emails:

```ruby
  Contact.skip_callback(:create, :after, :send_message)
  Contact.set_callback(:commit, :after, :send_message, on: :create)
```
