### PR TITLE
Only add names to draft registers

### DIFF
--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -78,7 +78,7 @@ class RegistersController < ApplicationController
         end
       when :draft
         authenticate_curator! && return
-        Register.where(validated: false, notified: false, submitted: false)
+        Register.drafts
       when :submitted
         authenticate_curator! && return
         Register.where(validated: false, notified: false, submitted: true)
@@ -129,8 +129,7 @@ class RegistersController < ApplicationController
   # GET /registers/new
   def new
     @register = Register.new
-    @registers =
-      current_user.registers.where(submitted: false, validated: false)
+    @registers = current_user.registers.drafts.order(created_at: :desc)
     @crumbs = ['Lists']
   end
 
@@ -145,7 +144,7 @@ class RegistersController < ApplicationController
       @register = Register.where(accession: params[:existing_register]).first
     end
     @register ||= Register.new(user: current_user)
-    @registers = current_user.registers.where(submitted: false)
+    @registers = current_user.registers.drafts.order(created_at: :desc)
 
     if @register.can_edit?(current_user) && @register.save &&
          (!@name || @name.add_to_register(@register, current_user)) &&

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1265,6 +1265,11 @@ class Name < ApplicationRecord
   # ============ --- REGISTER LISTS --- ============
 
   def add_to_register(register, user)
+    unless register&.draft?
+      errors.add(:register, 'must be a draft')
+      return false
+    end
+
     self.register = register
     unless created_by
       self.created_by = user

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -40,6 +40,8 @@ class Register < ApplicationRecord
   has_rich_text(:abstract)
   has_rich_text(:submitter_authorship_explanation)
 
+  scope :drafts, -> { where(validated: false, notified: false, submitted: false) }
+
   before_create(:assign_accession)
   before_validation(:propose_and_save_title, if: :submitted?)
   before_destroy(:return_names_to_draft)

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class NamesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @name = names(:one)
+    @name = names(:unregistered)
   end
 
 end

--- a/test/controllers/registers_controller_test.rb
+++ b/test/controllers/registers_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RegistersControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @register = registers(:one)
+    @register = registers(:draft)
   end
 
 end

--- a/test/controllers/registers_controller_test.rb
+++ b/test/controllers/registers_controller_test.rb
@@ -1,8 +1,35 @@
 require 'test_helper'
 
 class RegistersControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
   setup do
+    @user = users(:contributor)
     @register = registers(:draft)
+    @submitted_register = registers(:submitted)
+    @notified_register = registers(:notified)
+
+    sign_in(@user)
   end
 
+  test 'draft index only includes draft registers' do
+    get registers_path(status: :draft)
+
+    assert_response :success
+    assert_includes response.body, @register.acc_url
+    assert_not_includes response.body, @submitted_register.acc_url
+    assert_not_includes response.body, @notified_register.acc_url
+  end
+
+  test 'new register form only offers draft registers' do
+    get new_register_path
+
+    assert_response :success
+    assert_select 'select[name=existing_register]' do |select|
+      options = select.css('option').map(&:text).join(' ')
+      assert_includes options, @register.accession
+      assert_not_includes options, @submitted_register.accession
+      assert_not_includes options, @notified_register.accession
+    end
+  end
 end

--- a/test/controllers/registers_controller_test.rb
+++ b/test/controllers/registers_controller_test.rb
@@ -4,15 +4,16 @@ class RegistersControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
-    @user = users(:contributor)
+    @contributor = users(:contributor)
+    @curator = users(:curator)
     @register = registers(:draft)
     @submitted_register = registers(:submitted)
     @notified_register = registers(:notified)
-
-    sign_in(@user)
   end
 
   test 'draft index only includes draft registers' do
+    sign_in(@curator)
+
     get registers_path(status: :draft)
 
     assert_response :success
@@ -22,6 +23,8 @@ class RegistersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'new register form only offers draft registers' do
+    sign_in(@contributor)
+
     get new_register_path
 
     assert_response :success

--- a/test/fixtures/checks.yml
+++ b/test/fixtures/checks.yml
@@ -2,12 +2,12 @@
 
 one:
   name: one
-  user: one
+  user: contributor
   kind: MyText
   pass: false
 
 two:
   name: two
-  user: two
+  user: contributor
   kind: MyText
   pass: false

--- a/test/fixtures/checks.yml
+++ b/test/fixtures/checks.yml
@@ -2,12 +2,12 @@
 
 one:
   name: one
-  user: contributor
+  user: curator
   kind: MyText
   pass: false
 
 two:
   name: two
-  user: contributor
+  user: curator
   kind: MyText
   pass: false

--- a/test/fixtures/contacts.yml
+++ b/test/fixtures/contacts.yml
@@ -2,7 +2,7 @@
 
 one:
   publication: one
-  user: one
+  user: contributor
   to: MyString
   cc: MyString
   subject: MyString
@@ -10,7 +10,7 @@ one:
 
 two:
   publication: two
-  user: two
+  user: contributor
   to: MyString
   cc: MyString
   subject: MyString

--- a/test/fixtures/curations.yml
+++ b/test/fixtures/curations.yml
@@ -2,14 +2,14 @@
 
 one:
   name: one
-  user: contributor
+  user: curator
   kind_int: 1
   status_int: 1
   notes: MyText
 
 two:
   name: two
-  user: contributor
+  user: curator
   kind_int: 1
   status_int: 1
   notes: MyText

--- a/test/fixtures/curations.yml
+++ b/test/fixtures/curations.yml
@@ -2,14 +2,14 @@
 
 one:
   name: one
-  user: one
+  user: contributor
   kind_int: 1
   status_int: 1
   notes: MyText
 
 two:
   name: two
-  user: two
+  user: contributor
   kind_int: 1
   status_int: 1
   notes: MyText

--- a/test/fixtures/name_correspondences.yml
+++ b/test/fixtures/name_correspondences.yml
@@ -2,8 +2,8 @@
 
 one:
   name: one
-  user: one
+  user: contributor
 
 two:
   name: two
-  user: two
+  user: contributor

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -1,7 +1,4 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
+unregistered:
   name: MyString
-
-two:
-  name: MyOtherString

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -3,7 +3,7 @@
 one:
   seen: false
   notified_email: false
-  user: one
+  user: contributor
   notifiable: one
   notifiable_type: Notifiable
   linkeable: one
@@ -13,7 +13,7 @@ one:
 two:
   seen: false
   notified_email: false
-  user: two
+  user: contributor
   notifiable: two
   notifiable_type: Notifiable
   linkeable: two

--- a/test/fixtures/observe_names.yml
+++ b/test/fixtures/observe_names.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  user: one
+  user: contributor
   name: one
 
 two:
-  user: two
+  user: contributor
   name: two

--- a/test/fixtures/observe_registers.yml
+++ b/test/fixtures/observe_registers.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  user: one
+  user: contributor
   register: one
 
 two:
-  user: two
+  user: contributor
   register: two

--- a/test/fixtures/register_coauthors.yml
+++ b/test/fixtures/register_coauthors.yml
@@ -2,10 +2,10 @@
 
 one:
   register: one
-  user: one
+  user: contributor
   order: 1
 
 two:
   register: two
-  user: two
+  user: contributor
   order: 1

--- a/test/fixtures/register_correspondences.yml
+++ b/test/fixtures/register_correspondences.yml
@@ -2,8 +2,8 @@
 
 one:
   register: one
-  user: one
+  user: contributor
 
 two:
   register: two
-  user: two
+  user: contributor

--- a/test/fixtures/registers.yml
+++ b/test/fixtures/registers.yml
@@ -15,3 +15,11 @@ submitted:
   notified: false
   validated: false
   publication: one
+
+notified:
+  accession: r:notified01
+  user: contributor
+  submitted: false
+  notified: true
+  validated: false
+  publication: one

--- a/test/fixtures/registers.yml
+++ b/test/fixtures/registers.yml
@@ -1,17 +1,17 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  accession: MyString
-  user: one
-  validated_by: one
+draft:
+  accession: r:draft01
+  user: contributor
   submitted: false
+  notified: false
   validated: false
   publication: one
 
-two:
-  accession: MyOtherString
-  user: two
-  validated_by: two
-  submitted: false
+submitted:
+  accession: r:sumbit01
+  user: contributor
+  submitted: true
+  notified: false
   validated: false
-  publication: two
+  publication: one

--- a/test/fixtures/tutorials.yml
+++ b/test/fixtures/tutorials.yml
@@ -2,12 +2,12 @@
 
 one:
   pipeline: MyString
-  user: one
+  user: contributor
   ongoing: false
   step: 1
 
 two:
   pipeline: MyString
-  user: two
+  user: contributor
   ongoing: false
   step: 1

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,6 +4,13 @@ contributor:
   username: contributor
   email: contributor@example.com
   contributor: true
+  curator: false
+  confirmed_at: <%= Time.current %>
+
+curator:
+  username: curator
+  email: curator@example.com
+  contributor: true
   curator: true
   confirmed_at: <%= Time.current %>
 # column: value

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,10 +1,9 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  username: user_one
-  email: user_one@example.com
-
-two:
-  username: user_two
-  email: user_two@example.com
+contributor:
+  username: contributor
+  email: contributor@example.com
+  contributor: true
+  curator: true
+  confirmed_at: <%= Time.current %>
 # column: value

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1,7 +1,22 @@
 require 'test_helper'
 
 class NameTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'add_to_register adds name to a draft register' do
+    name = names(:unregistered)
+    register = registers(:draft)
+
+    assert register.draft?
+    assert name.add_to_register(register, users(:contributor))
+    assert_equal register, name.reload.register
+  end
+
+  test 'add_to_register refuses non-draft registers' do
+    name = names(:unregistered)
+    register = registers(:submitted)
+
+    assert_not register.draft?
+    assert_not name.add_to_register(register, users(:contributor))
+    assert_includes name.errors[:register], 'must be a draft'
+    assert_nil name.reload.register
+  end
 end

--- a/test/system/names_test.rb
+++ b/test/system/names_test.rb
@@ -1,6 +1,10 @@
 require 'application_system_test_case'
 
 class NamesTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:contributor)
+  end
+
   # test "visiting the index" do
   #   visit names_url
   #

--- a/test/system/registers_test.rb
+++ b/test/system/registers_test.rb
@@ -2,7 +2,7 @@ require 'application_system_test_case'
 
 class RegistersTest < ApplicationSystemTestCase
   setup do
-    @register = registers(:one)
+    @register = registers(:draft)
   end
 
 end


### PR DESCRIPTION
Fixes #216 

## Bug

The existing code in `RegistersController#new` has this guard:

```ruby
@registers = current_user.registers.where(submitted: false, validated: false)
```

This almost works, but includes registers that follow the path of going straight from `draft` to `notified`. They have both `submitted=false` and `validated=false` because they never went through that path.

## Change

This pull request does two things:

1. Adds a guard to `Name#add_to_register` to ensure that registers are in `draft`.
2. Adds a `drafts` scope to `Register`, which checks `where(validated: false, notified: false, submitted: false)`, and use that to select registers to show to the user in the dropdown.

No changes to the UI in this pull request, except that non-draft register lists are not in the dropdown.

## Alternative UI

I have a local change with a quick attempt at the table based interface we discussed. Not sure if we want to continue with that, I think the dropdown probably works well as long as you don't show the wrong registers. Thoughts?

<img width="2750" height="2062" alt="CleanShot-2026-06-29-12-58-08" src="https://github.com/user-attachments/assets/f1ecd63c-3be4-49cb-8fc1-276762ad2266" />
