### PR TITLE
Update link to SeqCode @ ISME

### DIFF
--- a/app/views/application/main.html.erb
+++ b/app/views/application/main.html.erb
@@ -20,7 +20,7 @@
   <h1>SeqCode Registry</h1>
   <p class="lead">
     Part of the
-    <a href="https://isme-microbes.org/seqcode-initiative"
+    <a href="https://isme-microbes.org/community/seqcode-initiative/activities/"
        target=_blank>SeqCode initiative</a>, a path forward for naming
     the uncultivated
   </p>
@@ -148,7 +148,7 @@
           <% end %>
         </div>
       </div>
-    <% end %>  
+    <% end %>
   </div>
 </div>
 


### PR DESCRIPTION
Tiny tiny thing. Current link points to an empty page:

<img width="3164" height="2062" alt="CleanShot-2026-06-30-10-57-03" src="https://github.com/user-attachments/assets/1425b0fb-abc7-4f32-baed-a9d1bd0ca4f3" />

New link goes to the Activities sub page:

<img width="3164" height="2062" alt="CleanShot-2026-06-30-10-57-35" src="https://github.com/user-attachments/assets/c866d513-7933-4e88-b49d-8e99df9022d4" />
